### PR TITLE
refactor(app): :recycle: explicitly ignore return errors

### DIFF
--- a/app/spawn.go
+++ b/app/spawn.go
@@ -59,13 +59,13 @@ func (g *Goful) SpawnSuspend(cmd string) {
 		widget.Init()
 		message.Info(cmd)
 	}(strings.Join(execCmd.Args, " "))
-	execCmd.Run()
+	_ = execCmd.Run()
 
 	shell := exec.Command(args[0])
 	shell.Stdin = os.Stdin
 	shell.Stdout = os.Stdout
 	shell.Stderr = os.Stderr
-	shell.Run()
+	_ = shell.Run()
 }
 
 const (

--- a/filer/directory.go
+++ b/filer/directory.go
@@ -135,7 +135,7 @@ func (s globDirPattern) String() string {
 }
 
 func (s globDirPattern) Read(callback func(string)) {
-	filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+	_ = filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if path == "." {
 			return nil
 		}

--- a/info/info_unix.go
+++ b/info/info_unix.go
@@ -19,7 +19,7 @@ func (w *infoWindow) draw(fi os.FileInfo) {
 	x, y := w.LeftTop()
 
 	var statfs syscall.Statfs_t
-	syscall.Statfs(".", &statfs)
+	_ = syscall.Statfs(".", &statfs)
 	free := statfs.Bavail * uint64(statfs.Bsize)
 	all := statfs.Blocks * uint64(statfs.Bsize)
 	used := float64(all-free) / float64(all) * 100

--- a/main.go
+++ b/main.go
@@ -31,12 +31,12 @@ func main() {
 
 	goful := app.NewGoful(state)
 	config(goful)
-	cmdline.LoadHistory(history)
+	_ = cmdline.LoadHistory(history)
 
 	goful.Run()
 
-	goful.SaveState(state)
-	cmdline.SaveHistory(history)
+	_ = goful.SaveState(state)
+	_ = cmdline.SaveHistory(history)
 }
 
 func config(g *app.Goful) {


### PR DESCRIPTION
Explicitly ignore return errors
    
It will be easier to refactor such ignores if mark them with blank assigment

