### PR TITLE
fix build on freebsd: statfs.Bavail is int64

### DIFF
--- a/info/info_unix.go
+++ b/info/info_unix.go
@@ -20,7 +20,7 @@ func (w *infoWindow) draw(fi os.FileInfo) {
 
 	var statfs syscall.Statfs_t
 	_ = syscall.Statfs(".", &statfs)
-	free := statfs.Bavail * uint64(statfs.Bsize)
+	free := uint64(statfs.Bavail) * uint64(statfs.Bsize)
 	all := statfs.Blocks * uint64(statfs.Bsize)
 	used := float64(all-free) / float64(all) * 100
 	freeSI := util.FormatSize(int64(free))


### PR DESCRIPTION
### Description:
This fixes build on FreeBSD (also runs with no errors).

Fix #17

### Checklist:
<!-- Please tick these as appropriate using [x] -->

- [ ] Tests all pass: `TestExpandMacro` fails on Linux and FreeBSD at `master`
- [ ] Lint and formatter run with no errors: `go fmt` adds `+//go:build`


